### PR TITLE
Use SHA-256 for checksums

### DIFF
--- a/src/ApplePayJS/ApplePayJS.csproj
+++ b/src/ApplePayJS/ApplePayJS.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AssemblyName>JustEat.ApplePayJS</AssemblyName>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <OutputType>Exe</OutputType>
     <PackageId>JustEat.ApplePayJS</PackageId>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>


### PR DESCRIPTION
Fix `BA2004` warning from Binskim.
