### PR TITLE
Fix compiler warning

### DIFF
--- a/tests/ApplePayJS.Tests/BrowserFixture.cs
+++ b/tests/ApplePayJS.Tests/BrowserFixture.cs
@@ -66,7 +66,9 @@ internal sealed class BrowserFixture(ITestOutputHelper? outputHelper)
 
         if (System.Diagnostics.Debugger.IsAttached)
         {
+#pragma warning disable CS0612
             options.Devtools = true;
+#pragma warning restore CS0612
             options.Headless = false;
             options.SlowMo = 100;
         }


### PR DESCRIPTION
Ignore obsolete warning on `DevTools` property.
