### PR TITLE
Add X-Frame-Options

### DIFF
--- a/src/ApplePayJS/web.config
+++ b/src/ApplePayJS/web.config
@@ -4,6 +4,7 @@
     <httpProtocol>
       <customHeaders>
         <remove name="X-Powered-By" />
+        <add name="X-Frame-Options" value="DENY" />
       </customHeaders>
     </httpProtocol>
   </system.webServer>


### PR DESCRIPTION
Resolve CodeQL `rule cs/web/missing-x-frame-options`.

I absently-mindedly enabled CodeQL on my fork and just noticed that it had a Code scanning alert this morning about `X-Frame-Options` not being set.

I made a similar change to one of my own repos on Friday (https://github.com/martincostello/SignInWithAppleSample/pull/634), this is the same change.
